### PR TITLE
feat: dynamic README update script

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,24 +1,22 @@
-name: Update Profile README
-
+name: Update README
 on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
   push:
     branches: [main]
-
-permissions:
-  contents: write
+    paths: ['scripts/**', 'templates/**']
 
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - run: pip install requests
       - run: python scripts/update_readme.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -44,33 +44,110 @@ mindmap
 
 | Repo | Description | Lang |
 |------|-------------|------|
-| [quickchpl](https://github.com/Jesssullivan/quickchpl) | Property-Based Testing for Chapel | Chapel |
-| [GloriousFlywheel](https://github.com/Jesssullivan/GloriousFlywheel) | Recursive IaC flywheel for GitLab | Shell |
-| [XoxdWM](https://github.com/Jesssullivan/XoxdWM) | Eye-gesture VR & BCI XWayland Emacs WM | Emacs Lisp |
-| [RemoteJuggler](https://github.com/Jesssullivan/RemoteJuggler) | Multi-identity git credential management | Shell |
-| [gnucashr](https://github.com/Jesssullivan/gnucashr) | High-perf accounting R package for GNUCash | R |
-| [pixelwise-research](https://github.com/Jesssullivan/pixelwise-research) | WebGPU glyph compositor in Futhark | Futhark |
-| [MerlinAI-Interpreters](https://github.com/Jesssullivan/MerlinAI-Interpreters) | Birdsong ML identification | Python |
-| [Arduino_Coil_Winder](https://github.com/Jesssullivan/Arduino_Coil_Winder) | Open-source stepper hardware | C++ |
-| [clipi](https://github.com/Jesssullivan/clipi) | Raspberry Pi automation tools | Python |
-| [mo-image-identifier](https://github.com/Jesssullivan/mo-image-identifier) | Mushroom identification for MushroomObserver | Python |
-| [Ansible-DAG-Harness](https://github.com/Jesssullivan/Ansible-DAG-Harness) | LangGraph DAG harness for Ansible | Python |
-
-<!--END_SECTION:repos-->
+| [GIS_Shortcuts](https://github.com/Jesssullivan/GIS_Shortcuts) | Jess's miscellaneous GIS notes and related tomfoolery  | R |
+| [GloriousFlywheel](https://github.com/Jesssullivan/GloriousFlywheel) | Recursive IaC flywheel infrastructure system for Gitlab. | HCL |
+| [tinyland-cleanup](https://github.com/Jesssullivan/tinyland-cleanup) | Cross-platform disk cleanup daemon with graduated thresholds | Go |
+| [tinyland-kdbx](https://github.com/Jesssullivan/tinyland-kdbx) | Native KeePassXC KDBX reader with base58 transport | Python |
+| [pp](https://github.com/Jesssullivan/pp) | Tinyland Lab shell dashboard with waifu integration | Go |
+| [XoxdWM](https://github.com/Jesssullivan/XoxdWM) | Eye-gesture VR & BCI XWayland Emacs Window Manager for transhumans and cyborgs | Emacs Lisp |
+| [hiberpower-ntfs](https://github.com/Jesssullivan/hiberpower-ntfs) | ASM2362 NVMe recovery experiments and research around FTL corruption | Zig |
+| [Ansible-DAG-Harness](https://github.com/Jesssullivan/Ansible-DAG-Harness) | A disposable self-bootstrapping LangGraph DAG harness for "boxing up"Ansible iteration cycles in Gitlab | Python |
+| [betterkvm](https://github.com/Jesssullivan/betterkvm) | The converged multiarch KVM for Tinyland NoneX86 contributions | Nix |
+| [DarwinNicUtil](https://github.com/Jesssullivan/DarwinNicUtil) | Extensible TUI utility for dealing with out-of-band management / air gapped network devices, mostly for institutionalized Macs (ABR, Sophos, NIC precedence etc)  | Python |
+| [RemoteJuggler](https://github.com/Jesssullivan/RemoteJuggler) | An identity management utility. Switch between multiple git identities with credential resolution, GPG + ssh signing, localized kdbx, be you a swarm of ten thousand clankers or even a human with a DE and a todolist. | Chapel |
+| [pixelwise-research](https://github.com/Jesssullivan/pixelwise-research) | An experimental webGPU glyph compositor demonstration in Futhark | TypeScript |
+| [gnucashr](https://github.com/Jesssullivan/gnucashr) | A high performance accounting and financial modeling R package for GNUCash | R |
+| [quickchpl](https://github.com/Jesssullivan/quickchpl) | Simple Property-Based Testing for Chapel Language | Chapel |
+| [tinyscale-mikrotik](https://github.com/Jesssullivan/tinyscale-mikrotik) | Very small tailscale container for CRS310 class switches | Shell |
+| [aoc-2025](https://github.com/Jesssullivan/aoc-2025) | Example usage of quickchpl PBT Mason library for a few AoC 2025 problems in CI | Chapel |
+| [tinywaffle](https://github.com/Jesssullivan/tinywaffle) |  | Dockerfile |
+| [searchies](https://github.com/Jesssullivan/searchies) | hard AF searxng infra for uwu tinies | Jinja |
+| [ts-caddy](https://github.com/Jesssullivan/ts-caddy) | Dreamhost DNS, Caddy, Tailscale, Dreamhost reverse proxy demo | Jinja |
+| [HCI-notes](https://github.com/Jesssullivan/HCI-notes) | Misc. notes to share on switch to Proxmox from Harvester | HCL |
+| [FastPhotoAPI](https://github.com/Jesssullivan/FastPhotoAPI) | An efficient, flexible, flask-based image server using Lanczos resampling  | Python |
+| [timberbuddy](https://github.com/Jesssullivan/timberbuddy) | Archive of Control Package work for Amish Sawmill | TypeScript |
+| [tetrahedron](https://github.com/Jesssullivan/tetrahedron) | Application for tetrahedron.gay mental health social service | Svelte |
+| [AccuWixReport](https://github.com/Jesssullivan/AccuWixReport) | A command line utility generating monthly transaction & superlative financial reports - migration between Acuity / Wix | Python |
+| [Jess-AOC-2023](https://github.com/Jesssullivan/Jess-AOC-2023) | Jess's solutions to the 2023 Advent of Code | Python |
+| [TurkeyProbe](https://github.com/Jesssullivan/TurkeyProbe) | for probing the Turkey | C++ |
+| [MerlinAI-Interpreters](https://github.com/Jesssullivan/MerlinAI-Interpreters) | Experiments, interpreter implementations, demos, data ingress tangents and lots of notes for birdsong identification  machine learning | TypeScript |
+| [IntroTypeScript](https://github.com/Jesssullivan/IntroTypeScript) | Learn how to write a command line utility of your own in pure modern TypeScript | TypeScript |
+| [NyxBox](https://github.com/Jesssullivan/NyxBox) | Posh & Fosh Litterbox |  |
+| [IG-3DP-Profiles](https://github.com/Jesssullivan/IG-3DP-Profiles) | Ithaca Generator 3d printer profiles and notes |  |
+| [TarrytownNY-Notes](https://github.com/Jesssullivan/TarrytownNY-Notes) |  | Jupyter Notebook |
+| [DLA-Flask](https://github.com/DLA-Makerspace/DLA-Flask) | Lightweight & responsive web dashboard application for DLA Makerspace | Jinja |
+| [MembershipWorks-Migration](https://github.com/Jesssullivan/MembershipWorks-Migration) |  | Jupyter Notebook |
+| [misc](https://github.com/Jesssullivan/misc) |  | Jupyter Notebook |
 
 ### FOSS Contributions
 
 | Fork | What |
 |------|------|
-| ![](https://img.shields.io/github/stars/Jesssullivan/chapel?style=social&label=chapel) | Parallel programming language |
-| ![](https://img.shields.io/github/stars/Jesssullivan/futhark?style=social&label=futhark) | GPU programming language |
-| ![](https://img.shields.io/github/stars/Jesssullivan/searxng?style=social&label=searxng) | Privacy-respecting search engine |
-| ![](https://img.shields.io/github/stars/Jesssullivan/skeleton?style=social&label=skeleton) | UI toolkit for Svelte |
-| ![](https://img.shields.io/github/stars/Jesssullivan/keepassxc?style=social&label=keepassxc) | Password manager |
-| ![](https://img.shields.io/github/stars/Jesssullivan/brainflow?style=social&label=brainflow) | Biosensor data library |
-| ![](https://img.shields.io/github/stars/Jesssullivan/solr?style=social&label=solr) | Apache search platform |
-| ![](https://img.shields.io/github/stars/Jesssullivan/meshcore?style=social&label=meshcore) | Mesh networking |
-| ![](https://img.shields.io/github/stars/Jesssullivan/eyetrackvr?style=social&label=eyetrackvr) | VR eye tracking |
+| ![](https://img.shields.io/github/stars/Jesssullivan/futhark?style=social&label=futhark) | :boom::computer::boom: A data-parallel functional programming language |
+| ![](https://img.shields.io/github/stars/Jesssullivan/futhark-webgpu?style=social&label=futhark-webgpu) | Materials and examples for using Futhark with WebGPU |
+| ![](https://img.shields.io/github/stars/Jesssullivan/freenet-stdlib?style=social&label=freenet-stdlib) | Freenet development standard library |
+| ![](https://img.shields.io/github/stars/Jesssullivan/chapel?style=social&label=chapel) | a Productive Parallel Programming Language |
+| ![](https://img.shields.io/github/stars/Jesssullivan/inferno?style=social&label=inferno) | [MIRROR] unofficial implementation of Dante protocol (Audio over IP) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/searxng?style=social&label=searxng) | SearXNG is a free internet metasearch engine which aggregates results from various search services and databases. Users are neither tracked nor profiled. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/skeleton?style=social&label=skeleton) | Skeleton is an adaptive design system powered by Tailwind CSS. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/brainflow?style=social&label=brainflow) | BrainFlow is a library intended to obtain, parse and analyze EEG, EMG, ECG and other kinds of data from biosensors |
+| ![](https://img.shields.io/github/stars/Jesssullivan/keepassxc?style=social&label=keepassxc) | KeePassXC is a cross-platform community-driven port of the Windows application “KeePass Password Safe”. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/eyetrackvr?style=social&label=eyetrackvr) | Free and Affordable, Virtual Reality Eye Tracking Platform. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/sveltekit-superforms?style=social&label=sveltekit-superforms) | Making SvelteKit forms a pleasure to use! |
+| ![](https://img.shields.io/github/stars/Jesssullivan/mason-registry?style=social&label=mason-registry) | Package registry for mason, Chapel's package manager |
+| ![](https://img.shields.io/github/stars/Jesssullivan/xelb?style=social&label=xelb) | X protocol Emacs Lisp Binding |
+| ![](https://img.shields.io/github/stars/Jesssullivan/liqo?style=social&label=liqo) | Enable dynamic and seamless Kubernetes multi-cluster topologies |
+| ![](https://img.shields.io/github/stars/Jesssullivan/meshcore?style=social&label=meshcore) | A new lightweight, hybrid routing mesh protocol for packet radios |
+| ![](https://img.shields.io/github/stars/Jesssullivan/elinks?style=social&label=elinks) | Fork of elinks |
+| ![](https://img.shields.io/github/stars/Jesssullivan/solr?style=social&label=solr) | Apache Solr open-source search software |
+| ![](https://img.shields.io/github/stars/Jesssullivan/go-containerregistry?style=social&label=go-containerregistry) | Go library and CLIs for working with container registries |
+| ![](https://img.shields.io/github/stars/Jesssullivan/MicroManipulatorStepper?style=social&label=MicroManipulatorStepper) | A sub-micrometer 3D motion control plattform. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/searxng-docker?style=social&label=searxng-docker) | The docker-compose files for setting up a SearXNG instance with docker. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/ruv-FANN?style=social&label=ruv-FANN) | A blazing-fast, memory-safe neural network library for Rust that brings the power of FANN to the modern world. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/nvim?style=social&label=nvim) | minimal yet functional neovim |
+| ![](https://img.shields.io/github/stars/Jesssullivan/CVE-2025-32463_chwoot?style=social&label=CVE-2025-32463_chwoot) | Escalation of Privilege to the root through sudo binary with chroot option. CVE-2025-32463 |
+| ![](https://img.shields.io/github/stars/Jesssullivan/void?style=social&label=void) |  |
+| ![](https://img.shields.io/github/stars/Jesssullivan/xcaddy?style=social&label=xcaddy) | Build Caddy with plugins |
+| ![](https://img.shields.io/github/stars/Jesssullivan/caddy-supervisor?style=social&label=caddy-supervisor) | Run and supervise background processes from Caddy |
+| ![](https://img.shields.io/github/stars/Jesssullivan/dreamhost?style=social&label=dreamhost) |  |
+| ![](https://img.shields.io/github/stars/Jesssullivan/libdns-dreamhost?style=social&label=libdns-dreamhost) |  |
+| ![](https://img.shields.io/github/stars/Jesssullivan/caddy?style=social&label=caddy) | Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS |
+| ![](https://img.shields.io/github/stars/Jesssullivan/S4_Slicer?style=social&label=S4_Slicer) | Generic Non-Planar Slicer |
+| ![](https://img.shields.io/github/stars/Jesssullivan/caddy-anubis?style=social&label=caddy-anubis) | A caddy plugin to place Anubis (anti-AI scrapper) directly within caddy as a middleware. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/solr-mcp?style=social&label=solr-mcp) | A Python package for accessing Solr indexes via Claude Code |
+| ![](https://img.shields.io/github/stars/Jesssullivan/voltha-helm-charts?style=social&label=voltha-helm-charts) |  |
+| ![](https://img.shields.io/github/stars/Jesssullivan/NanoKVM?style=social&label=NanoKVM) | NanoKVM: Affordable, Multifunctional, Nano RISC-V IP-KVM |
+| ![](https://img.shields.io/github/stars/Jesssullivan/fenrir?style=social&label=fenrir) | The leader of the pack - control multiple distributed instances of Wolf in K8S |
+| ![](https://img.shields.io/github/stars/Jesssullivan/youtube-dl?style=social&label=youtube-dl) | Command-line program to download videos from YouTube.com and other video sites |
+| ![](https://img.shields.io/github/stars/Jesssullivan/ansible?style=social&label=ansible) | collection of ansible roles and playbooks to enable self-hosters full control of their infrastructure |
+| ![](https://img.shields.io/github/stars/Jesssullivan/easy-openwrt-builder?style=social&label=easy-openwrt-builder) | A simple framework for building customized OpenWRT images with additional options for virtual machine conversion & embedded parition resizing |
+| ![](https://img.shields.io/github/stars/Jesssullivan/rockylinux.org?style=social&label=rockylinux.org) | The official website of the Rocky Linux project. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/klipper?style=social&label=klipper) | Klipper is a 3d-printer firmware |
+| ![](https://img.shields.io/github/stars/Jesssullivan/prind-dangerklipper?style=social&label=prind-dangerklipper) | print in docker - Deploy a containerized Klipper Stack for your 3D Printer |
+| ![](https://img.shields.io/github/stars/Jesssullivan/example-sveltekit-email-password-webauthn?style=social&label=example-sveltekit-email-password-webauthn) | Email and password example with 2FA and WebAuthn in SvelteKit |
+| ![](https://img.shields.io/github/stars/Jesssullivan/mod-desktop?style=social&label=mod-desktop) | MOD Audio for the desktop |
+| ![](https://img.shields.io/github/stars/Jesssullivan/Takeoff-Toolhead?style=social&label=Takeoff-Toolhead) | A SLM Toolhead using 3628 Fans and Chube (Formerly Called Jaguar) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/traccar-client-android?style=social&label=traccar-client-android) | Traccar Client for Android |
+| ![](https://img.shields.io/github/stars/Jesssullivan/k8sy-windows?style=social&label=k8sy-windows) | Windows inside a Docker container. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/neural-amp-modeler-ui?style=social&label=neural-amp-modeler-ui) | This is a GUI for the Neural Amp Modeler LV2 plugin |
+| ![](https://img.shields.io/github/stars/Jesssullivan/linux-client-for-icloud-notes?style=social&label=linux-client-for-icloud-notes) | A Linux client for your iCloud Notes service |
+| ![](https://img.shields.io/github/stars/Jesssullivan/ntlm-transport?style=social&label=ntlm-transport) | NTLM reverse proxy transport module for Caddy |
+| ![](https://img.shields.io/github/stars/Jesssullivan/IG-3DP-Profiles?style=social&label=IG-3DP-Profiles) | Ithaca Generator 3d printer profiles and notes |
+| ![](https://img.shields.io/github/stars/Jesssullivan/ml-in-a-box?style=social&label=ml-in-a-box) | Machine learning tool-set for Paperspace VMs |
+| ![](https://img.shields.io/github/stars/Jesssullivan/find3?style=social&label=find3) | High-precision indoor positioning framework, version 3. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/eui-event-template?style=social&label=eui-event-template) |  |
+| ![](https://img.shields.io/github/stars/Jesssullivan/ConicalSlicer?style=social&label=ConicalSlicer) | Python Scripts for Conical GCode Slicing |
+| ![](https://img.shields.io/github/stars/Jesssullivan/vectiler?style=social&label=vectiler) | A vector tile, terrain and city 3d model builder and exporter |
+| ![](https://img.shields.io/github/stars/Jesssullivan/MembershipWorks-Migration?style=social&label=MembershipWorks-Migration) |  |
+| ![](https://img.shields.io/github/stars/Jesssullivan/PrintABrick?style=social&label=PrintABrick) | Web catalogue of LEGO® parts for 3D printing |
+| ![](https://img.shields.io/github/stars/Jesssullivan/github-markdown-css?style=social&label=github-markdown-css) | The minimal amount of CSS to replicate the GitHub Markdown style |
+| ![](https://img.shields.io/github/stars/Jesssullivan/Kelp?style=social&label=Kelp) | Kelp is a web-based GUI for SeaweedFS, meant to emulate the look and feel of a native file explorer. |
+| ![](https://img.shields.io/github/stars/Jesssullivan/IGOnBoard?style=social&label=IGOnBoard) |  |
+| ![](https://img.shields.io/github/stars/Jesssullivan/VVV?style=social&label=VVV) | An open source Vagrant configuration for developing with WordPress |
+| ![](https://img.shields.io/github/stars/Jesssullivan/ajax-solr?style=social&label=ajax-solr) | A JavaScript framework for creating user interfaces to Solr. |
+
+*Last updated: 2026-02-10 03:14 UTC*
+<!--END_SECTION:repos-->
 
 ---
 
@@ -87,4 +164,3 @@ mindmap
 
 *This README is updated daily by a [GitHub Action](.github/workflows/update-readme.yml).*
 
-*Last manual edit: 2026-02-09*

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -1,37 +1,27 @@
 #!/usr/bin/env python3
-"""Update the profile README with latest repo data from GitHub GraphQL API."""
+"""Update the profile README with latest repo data from GitHub GraphQL API.
+
+Uses only stdlib + urllib (no pip installs needed).
+"""
 
 import json
 import os
 import re
+import urllib.request
 from datetime import datetime, timezone
-
-import requests
 
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 GRAPHQL_URL = "https://api.github.com/graphql"
 README_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
 
-# Repos to exclude from the dynamic listing
-EXCLUDE_REPOS = {
-    "Jesssullivan",  # profile repo itself
-    "jesssullivan.github.io",  # blog
+# Repos to exclude (test/trivial/profile)
+BLOCKLIST = {
+    "test",
+    "testing",
+    "test-repo",
+    "hello-world",
+    "Jesssullivan",
 }
-
-# Repos to always show (showcase)
-SHOWCASE_REPOS = [
-    "quickchpl",
-    "GloriousFlywheel",
-    "XoxdWM",
-    "RemoteJuggler",
-    "gnucashr",
-    "pixelwise-research",
-    "MerlinAI-Interpreters",
-    "Arduino_Coil_Winder",
-    "clipi",
-    "mo-image-identifier",
-    "Ansible-DAG-Harness",
-]
 
 QUERY = """
 {
@@ -43,9 +33,8 @@ QUERY = """
         url
         primaryLanguage { name }
         stargazerCount
-        forkCount
-        pushedAt
         isFork
+        parent { nameWithOwner }
       }
     }
   }
@@ -54,57 +43,105 @@ QUERY = """
 
 
 def fetch_repos():
+    """Fetch public repos via GitHub GraphQL API using urllib."""
     headers = {
         "Authorization": f"Bearer {GITHUB_TOKEN}",
         "Content-Type": "application/json",
+        "User-Agent": "profile-readme-updater",
     }
-    resp = requests.post(GRAPHQL_URL, json={"query": QUERY}, headers=headers)
-    resp.raise_for_status()
-    data = resp.json()
+    payload = json.dumps({"query": QUERY}).encode("utf-8")
+    req = urllib.request.Request(GRAPHQL_URL, data=payload, headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL errors: {data['errors']}")
     return data["data"]["user"]["repositories"]["nodes"]
 
 
-def format_repo_table(repos):
+def should_include(repo):
+    """Return True if the repo should appear in the README."""
+    name = repo["name"]
+    if name.lower() in {b.lower() for b in BLOCKLIST}:
+        return False
+    # Exclude repos with no description AND no primary language
+    has_desc = bool(repo.get("description"))
+    has_lang = bool(repo.get("primaryLanguage"))
+    if not has_desc and not has_lang:
+        return False
+    return True
+
+
+def build_original_table(repos):
+    """Build markdown table for non-fork (original) repos."""
     lines = ["| Repo | Description | Lang |", "|------|-------------|------|"]
     for repo in repos:
         name = repo["name"]
-        if name in EXCLUDE_REPOS:
-            continue
         desc = (repo["description"] or "").replace("|", "\\|")
-        lang = repo.get("primaryLanguage", {})
+        lang = repo.get("primaryLanguage")
         lang_name = lang["name"] if lang else ""
         url = repo["url"]
         lines.append(f"| [{name}]({url}) | {desc} | {lang_name} |")
     return "\n".join(lines)
 
 
-def update_section(content, section_name, new_content):
-    pattern = rf"(<!--START_SECTION:{section_name}-->).*?(<!--END_SECTION:{section_name}-->)"
+def build_forks_table(repos):
+    """Build markdown table for forked repos with star badges."""
+    lines = ["| Fork | What |", "|------|------|"]
+    for repo in repos:
+        name = repo["name"]
+        desc = (repo["description"] or "").replace("|", "\\|")
+        badge = f"![](https://img.shields.io/github/stars/Jesssullivan/{name}?style=social&label={name})"
+        lines.append(f"| {badge} | {desc} |")
+    return "\n".join(lines)
+
+
+def update_section(content, new_content):
+    """Replace content between START_SECTION:repos and END_SECTION:repos markers."""
+    pattern = r"(<!--START_SECTION:repos-->).*?(<!--END_SECTION:repos-->)"
     replacement = rf"\1\n{new_content}\n\2"
     return re.sub(pattern, replacement, content, flags=re.DOTALL)
 
 
 def main():
     if not GITHUB_TOKEN:
-        print("GITHUB_TOKEN not set, skipping update")
+        print("Error: GITHUB_TOKEN not set")
         return
 
     repos = fetch_repos()
-    showcase = [r for r in repos if r["name"] in SHOWCASE_REPOS and not r["isFork"]]
-    # Sort showcase by the predefined order
-    showcase.sort(key=lambda r: SHOWCASE_REPOS.index(r["name"]) if r["name"] in SHOWCASE_REPOS else 999)
+    included = [r for r in repos if should_include(r)]
+    originals = [r for r in included if not r["isFork"]]
+    forks = [r for r in included if r["isFork"]]
 
-    table = format_repo_table(showcase)
+    print(f"Found {len(originals)} original repos, {len(forks)} forks")
+
+    # Build the combined section content
+    section_parts = []
+
+    # Original Projects table
+    section_parts.append("")
+    section_parts.append(build_original_table(originals))
+    section_parts.append("")
+
+    # FOSS Contributions heading + table
+    section_parts.append("### FOSS Contributions")
+    section_parts.append("")
+    section_parts.append(build_forks_table(forks))
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    section_parts.append("")
+    section_parts.append(f"*Last updated: {now}*")
+
+    section_content = "\n".join(section_parts)
 
     with open(README_PATH, "r") as f:
         content = f.read()
 
-    content = update_section(content, "repos", table)
+    content = update_section(content, section_content)
 
     with open(README_PATH, "w") as f:
         f.write(content)
 
-    print(f"Updated README with {len(showcase)} showcase repos")
+    print(f"Updated README with {len(originals)} original repos and {len(forks)} forks")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds Python script that queries GitHub GraphQL API for repo data
- Generates markdown tables for original projects and FOSS forks
- GitHub Actions workflow runs daily + on push to keep README current

## Test plan
- [ ] Trigger workflow_dispatch manually from Actions tab
- [ ] Verify README updates with live repo data