### PR TITLE
feat: enhance README with activity section and table limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ mindmap
 </td></tr>
 </table>
 
+<!--START_SECTION:activity-->
+**Currently working on:** [GloriousFlywheel](https://github.com/Jesssullivan/GloriousFlywheel)
+  Recursive IaC flywheel infrastructure system for Gitlab.
+  *HCL · last push today*
+<!--END_SECTION:activity-->
+
 <!--START_SECTION:blog-->
 ### Latest Blog Posts
 
@@ -61,10 +67,10 @@ mindmap
 | [pp](https://github.com/Jesssullivan/pp) | Tinyland Lab shell dashboard with waifu integration | Go |
 | [XoxdWM](https://github.com/Jesssullivan/XoxdWM) | Eye-gesture VR & BCI XWayland Emacs Window Manager for transhumans and cyborgs | Emacs Lisp |
 | [hiberpower-ntfs](https://github.com/Jesssullivan/hiberpower-ntfs) | ASM2362 NVMe recovery experiments and research around FTL corruption | Zig |
-| [Ansible-DAG-Harness](https://github.com/Jesssullivan/Ansible-DAG-Harness) | A disposable self-bootstrapping LangGraph DAG harness for "boxing up"Ansible iteration cycles in Gitlab | Python |
+| [Ansible-DAG-Harness](https://github.com/Jesssullivan/Ansible-DAG-Harness) | A disposable self-bootstrapping LangGraph DAG harness for "boxing up"Ansible iteration cycles in ... | Python |
 | [betterkvm](https://github.com/Jesssullivan/betterkvm) | The converged multiarch KVM for Tinyland NoneX86 contributions | Nix |
-| [DarwinNicUtil](https://github.com/Jesssullivan/DarwinNicUtil) | Extensible TUI utility for dealing with out-of-band management / air gapped network devices, mostly for institutionalized Macs (ABR, Sophos, NIC precedence etc)  | Python |
-| [RemoteJuggler](https://github.com/Jesssullivan/RemoteJuggler) | An identity management utility. Switch between multiple git identities with credential resolution, GPG + ssh signing, localized kdbx, be you a swarm of ten thousand clankers or even a human with a DE and a todolist. | Chapel |
+| [DarwinNicUtil](https://github.com/Jesssullivan/DarwinNicUtil) | Extensible TUI utility for dealing with out-of-band management / air gapped network devices, most... | Python |
+| [RemoteJuggler](https://github.com/Jesssullivan/RemoteJuggler) | An identity management utility. Switch between multiple git identities with credential resolution... | Chapel |
 | [pixelwise-research](https://github.com/Jesssullivan/pixelwise-research) | An experimental webGPU glyph compositor demonstration in Futhark | TypeScript |
 | [gnucashr](https://github.com/Jesssullivan/gnucashr) | A high performance accounting and financial modeling R package for GNUCash | R |
 | [quickchpl](https://github.com/Jesssullivan/quickchpl) | Simple Property-Based Testing for Chapel Language | Chapel |
@@ -74,89 +80,32 @@ mindmap
 | [searchies](https://github.com/Jesssullivan/searchies) | hard AF searxng infra for uwu tinies | Jinja |
 | [ts-caddy](https://github.com/Jesssullivan/ts-caddy) | Dreamhost DNS, Caddy, Tailscale, Dreamhost reverse proxy demo | Jinja |
 | [HCI-notes](https://github.com/Jesssullivan/HCI-notes) | Misc. notes to share on switch to Proxmox from Harvester | HCL |
-| [FastPhotoAPI](https://github.com/Jesssullivan/FastPhotoAPI) | An efficient, flexible, flask-based image server using Lanczos resampling  | Python |
-| [timberbuddy](https://github.com/Jesssullivan/timberbuddy) | Archive of Control Package work for Amish Sawmill | TypeScript |
-| [tetrahedron](https://github.com/Jesssullivan/tetrahedron) | Application for tetrahedron.gay mental health social service | Svelte |
-| [AccuWixReport](https://github.com/Jesssullivan/AccuWixReport) | A command line utility generating monthly transaction & superlative financial reports - migration between Acuity / Wix | Python |
-| [Jess-AOC-2023](https://github.com/Jesssullivan/Jess-AOC-2023) | Jess's solutions to the 2023 Advent of Code | Python |
-| [TurkeyProbe](https://github.com/Jesssullivan/TurkeyProbe) | for probing the Turkey | C++ |
-| [MerlinAI-Interpreters](https://github.com/Jesssullivan/MerlinAI-Interpreters) | Experiments, interpreter implementations, demos, data ingress tangents and lots of notes for birdsong identification  machine learning | TypeScript |
-| [IntroTypeScript](https://github.com/Jesssullivan/IntroTypeScript) | Learn how to write a command line utility of your own in pure modern TypeScript | TypeScript |
-| [NyxBox](https://github.com/Jesssullivan/NyxBox) | Posh & Fosh Litterbox |  |
-| [IG-3DP-Profiles](https://github.com/Jesssullivan/IG-3DP-Profiles) | Ithaca Generator 3d printer profiles and notes |  |
-| [TarrytownNY-Notes](https://github.com/Jesssullivan/TarrytownNY-Notes) |  | Jupyter Notebook |
-| [DLA-Flask](https://github.com/DLA-Makerspace/DLA-Flask) | Lightweight & responsive web dashboard application for DLA Makerspace | Jinja |
-| [MembershipWorks-Migration](https://github.com/Jesssullivan/MembershipWorks-Migration) |  | Jupyter Notebook |
-| [misc](https://github.com/Jesssullivan/misc) |  | Jupyter Notebook |
+
+*...and [11 more](https://github.com/Jesssullivan?tab=repositories&type=source)*
 
 ### FOSS Contributions
 
-| Fork | What |
-|------|------|
-| ![](https://img.shields.io/github/stars/Jesssullivan/futhark?style=social&label=futhark) | :boom::computer::boom: A data-parallel functional programming language |
-| ![](https://img.shields.io/github/stars/Jesssullivan/futhark-webgpu?style=social&label=futhark-webgpu) | Materials and examples for using Futhark with WebGPU |
-| ![](https://img.shields.io/github/stars/Jesssullivan/freenet-stdlib?style=social&label=freenet-stdlib) | Freenet development standard library |
-| ![](https://img.shields.io/github/stars/Jesssullivan/chapel?style=social&label=chapel) | a Productive Parallel Programming Language |
-| ![](https://img.shields.io/github/stars/Jesssullivan/inferno?style=social&label=inferno) | [MIRROR] unofficial implementation of Dante protocol (Audio over IP) |
-| ![](https://img.shields.io/github/stars/Jesssullivan/searxng?style=social&label=searxng) | SearXNG is a free internet metasearch engine which aggregates results from various search services and databases. Users are neither tracked nor profiled. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/skeleton?style=social&label=skeleton) | Skeleton is an adaptive design system powered by Tailwind CSS. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/brainflow?style=social&label=brainflow) | BrainFlow is a library intended to obtain, parse and analyze EEG, EMG, ECG and other kinds of data from biosensors |
-| ![](https://img.shields.io/github/stars/Jesssullivan/keepassxc?style=social&label=keepassxc) | KeePassXC is a cross-platform community-driven port of the Windows application “KeePass Password Safe”. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/eyetrackvr?style=social&label=eyetrackvr) | Free and Affordable, Virtual Reality Eye Tracking Platform. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/sveltekit-superforms?style=social&label=sveltekit-superforms) | Making SvelteKit forms a pleasure to use! |
-| ![](https://img.shields.io/github/stars/Jesssullivan/mason-registry?style=social&label=mason-registry) | Package registry for mason, Chapel's package manager |
-| ![](https://img.shields.io/github/stars/Jesssullivan/xelb?style=social&label=xelb) | X protocol Emacs Lisp Binding |
-| ![](https://img.shields.io/github/stars/Jesssullivan/liqo?style=social&label=liqo) | Enable dynamic and seamless Kubernetes multi-cluster topologies |
-| ![](https://img.shields.io/github/stars/Jesssullivan/meshcore?style=social&label=meshcore) | A new lightweight, hybrid routing mesh protocol for packet radios |
-| ![](https://img.shields.io/github/stars/Jesssullivan/elinks?style=social&label=elinks) | Fork of elinks |
-| ![](https://img.shields.io/github/stars/Jesssullivan/solr?style=social&label=solr) | Apache Solr open-source search software |
-| ![](https://img.shields.io/github/stars/Jesssullivan/go-containerregistry?style=social&label=go-containerregistry) | Go library and CLIs for working with container registries |
-| ![](https://img.shields.io/github/stars/Jesssullivan/MicroManipulatorStepper?style=social&label=MicroManipulatorStepper) | A sub-micrometer 3D motion control plattform. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/searxng-docker?style=social&label=searxng-docker) | The docker-compose files for setting up a SearXNG instance with docker. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/ruv-FANN?style=social&label=ruv-FANN) | A blazing-fast, memory-safe neural network library for Rust that brings the power of FANN to the modern world. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/nvim?style=social&label=nvim) | minimal yet functional neovim |
-| ![](https://img.shields.io/github/stars/Jesssullivan/CVE-2025-32463_chwoot?style=social&label=CVE-2025-32463_chwoot) | Escalation of Privilege to the root through sudo binary with chroot option. CVE-2025-32463 |
-| ![](https://img.shields.io/github/stars/Jesssullivan/void?style=social&label=void) |  |
-| ![](https://img.shields.io/github/stars/Jesssullivan/xcaddy?style=social&label=xcaddy) | Build Caddy with plugins |
-| ![](https://img.shields.io/github/stars/Jesssullivan/caddy-supervisor?style=social&label=caddy-supervisor) | Run and supervise background processes from Caddy |
-| ![](https://img.shields.io/github/stars/Jesssullivan/dreamhost?style=social&label=dreamhost) |  |
-| ![](https://img.shields.io/github/stars/Jesssullivan/libdns-dreamhost?style=social&label=libdns-dreamhost) |  |
-| ![](https://img.shields.io/github/stars/Jesssullivan/caddy?style=social&label=caddy) | Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS |
-| ![](https://img.shields.io/github/stars/Jesssullivan/S4_Slicer?style=social&label=S4_Slicer) | Generic Non-Planar Slicer |
-| ![](https://img.shields.io/github/stars/Jesssullivan/caddy-anubis?style=social&label=caddy-anubis) | A caddy plugin to place Anubis (anti-AI scrapper) directly within caddy as a middleware. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/solr-mcp?style=social&label=solr-mcp) | A Python package for accessing Solr indexes via Claude Code |
-| ![](https://img.shields.io/github/stars/Jesssullivan/voltha-helm-charts?style=social&label=voltha-helm-charts) |  |
-| ![](https://img.shields.io/github/stars/Jesssullivan/NanoKVM?style=social&label=NanoKVM) | NanoKVM: Affordable, Multifunctional, Nano RISC-V IP-KVM |
-| ![](https://img.shields.io/github/stars/Jesssullivan/fenrir?style=social&label=fenrir) | The leader of the pack - control multiple distributed instances of Wolf in K8S |
-| ![](https://img.shields.io/github/stars/Jesssullivan/youtube-dl?style=social&label=youtube-dl) | Command-line program to download videos from YouTube.com and other video sites |
-| ![](https://img.shields.io/github/stars/Jesssullivan/ansible?style=social&label=ansible) | collection of ansible roles and playbooks to enable self-hosters full control of their infrastructure |
-| ![](https://img.shields.io/github/stars/Jesssullivan/easy-openwrt-builder?style=social&label=easy-openwrt-builder) | A simple framework for building customized OpenWRT images with additional options for virtual machine conversion & embedded parition resizing |
-| ![](https://img.shields.io/github/stars/Jesssullivan/rockylinux.org?style=social&label=rockylinux.org) | The official website of the Rocky Linux project. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/klipper?style=social&label=klipper) | Klipper is a 3d-printer firmware |
-| ![](https://img.shields.io/github/stars/Jesssullivan/prind-dangerklipper?style=social&label=prind-dangerklipper) | print in docker - Deploy a containerized Klipper Stack for your 3D Printer |
-| ![](https://img.shields.io/github/stars/Jesssullivan/example-sveltekit-email-password-webauthn?style=social&label=example-sveltekit-email-password-webauthn) | Email and password example with 2FA and WebAuthn in SvelteKit |
-| ![](https://img.shields.io/github/stars/Jesssullivan/mod-desktop?style=social&label=mod-desktop) | MOD Audio for the desktop |
-| ![](https://img.shields.io/github/stars/Jesssullivan/Takeoff-Toolhead?style=social&label=Takeoff-Toolhead) | A SLM Toolhead using 3628 Fans and Chube (Formerly Called Jaguar) |
-| ![](https://img.shields.io/github/stars/Jesssullivan/traccar-client-android?style=social&label=traccar-client-android) | Traccar Client for Android |
-| ![](https://img.shields.io/github/stars/Jesssullivan/k8sy-windows?style=social&label=k8sy-windows) | Windows inside a Docker container. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/neural-amp-modeler-ui?style=social&label=neural-amp-modeler-ui) | This is a GUI for the Neural Amp Modeler LV2 plugin |
-| ![](https://img.shields.io/github/stars/Jesssullivan/linux-client-for-icloud-notes?style=social&label=linux-client-for-icloud-notes) | A Linux client for your iCloud Notes service |
-| ![](https://img.shields.io/github/stars/Jesssullivan/ntlm-transport?style=social&label=ntlm-transport) | NTLM reverse proxy transport module for Caddy |
-| ![](https://img.shields.io/github/stars/Jesssullivan/IG-3DP-Profiles?style=social&label=IG-3DP-Profiles) | Ithaca Generator 3d printer profiles and notes |
-| ![](https://img.shields.io/github/stars/Jesssullivan/ml-in-a-box?style=social&label=ml-in-a-box) | Machine learning tool-set for Paperspace VMs |
-| ![](https://img.shields.io/github/stars/Jesssullivan/find3?style=social&label=find3) | High-precision indoor positioning framework, version 3. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/eui-event-template?style=social&label=eui-event-template) |  |
-| ![](https://img.shields.io/github/stars/Jesssullivan/ConicalSlicer?style=social&label=ConicalSlicer) | Python Scripts for Conical GCode Slicing |
-| ![](https://img.shields.io/github/stars/Jesssullivan/vectiler?style=social&label=vectiler) | A vector tile, terrain and city 3d model builder and exporter |
-| ![](https://img.shields.io/github/stars/Jesssullivan/MembershipWorks-Migration?style=social&label=MembershipWorks-Migration) |  |
-| ![](https://img.shields.io/github/stars/Jesssullivan/PrintABrick?style=social&label=PrintABrick) | Web catalogue of LEGO® parts for 3D printing |
-| ![](https://img.shields.io/github/stars/Jesssullivan/github-markdown-css?style=social&label=github-markdown-css) | The minimal amount of CSS to replicate the GitHub Markdown style |
-| ![](https://img.shields.io/github/stars/Jesssullivan/Kelp?style=social&label=Kelp) | Kelp is a web-based GUI for SeaweedFS, meant to emulate the look and feel of a native file explorer. |
-| ![](https://img.shields.io/github/stars/Jesssullivan/IGOnBoard?style=social&label=IGOnBoard) |  |
-| ![](https://img.shields.io/github/stars/Jesssullivan/VVV?style=social&label=VVV) | An open source Vagrant configuration for developing with WordPress |
-| ![](https://img.shields.io/github/stars/Jesssullivan/ajax-solr?style=social&label=ajax-solr) | A JavaScript framework for creating user interfaces to Solr. |
+| Fork | Upstream |
+|------|----------|
+| ![](https://img.shields.io/github/stars/Jesssullivan/inferno?style=social&label=inferno) | [teodly/inferno](https://github.com/teodly/inferno) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/searxng?style=social&label=searxng) | [searxng/searxng](https://github.com/searxng/searxng) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/skeleton?style=social&label=skeleton) | [skeletonlabs/skeleton](https://github.com/skeletonlabs/skeleton) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/liqo?style=social&label=liqo) | [liqotech/liqo](https://github.com/liqotech/liqo) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/meshcore?style=social&label=meshcore) | [meshcore-dev/MeshCore](https://github.com/meshcore-dev/MeshCore) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/solr?style=social&label=solr) | [apache/solr](https://github.com/apache/solr) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/go-containerregistry?style=social&label=go-containerregistry) | [google/go-containerregistry](https://github.com/google/go-containerregistry) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/MicroManipulatorStepper?style=social&label=MicroManipulatorStepper) | [0x23/MicroManipulatorStepper](https://github.com/0x23/MicroManipulatorStepper) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/ruv-FANN?style=social&label=ruv-FANN) | [ruvnet/ruv-FANN](https://github.com/ruvnet/ruv-FANN) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/CVE-2025-32463_chwoot?style=social&label=CVE-2025-32463_chwoot) | [pr0v3rbs/CVE-2025-32463_chwoot](https://github.com/pr0v3rbs/CVE-2025-32463_chwoot) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/IG-3DP-Profiles?style=social&label=IG-3DP-Profiles) | [Jesssullivan/IG-3DP-Profiles](https://github.com/Jesssullivan/IG-3DP-Profiles) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/futhark?style=social&label=futhark) | [diku-dk/futhark](https://github.com/diku-dk/futhark) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/futhark-webgpu?style=social&label=futhark-webgpu) | [diku-dk/futhark-webgpu](https://github.com/diku-dk/futhark-webgpu) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/freenet-stdlib?style=social&label=freenet-stdlib) | [freenet/freenet-stdlib](https://github.com/freenet/freenet-stdlib) |
+| ![](https://img.shields.io/github/stars/Jesssullivan/chapel?style=social&label=chapel) | [chapel-lang/chapel](https://github.com/chapel-lang/chapel) |
 
-*Last updated: 2026-02-10 04:00 UTC*
+*...and [46 more forks](https://github.com/Jesssullivan?tab=repositories&type=fork)*
+
+*Last updated: 2026-02-10 04:28 UTC*
 <!--END_SECTION:repos-->
 
 ---

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -15,14 +15,20 @@ GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 GRAPHQL_URL = "https://api.github.com/graphql"
 README_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "README.md")
 
-# Repos to exclude (test/trivial/profile)
+# Repos to exclude from the README entirely
 BLOCKLIST = {
-    "test",
-    "testing",
-    "test-repo",
-    "hello-world",
-    "Jesssullivan",
+    "test", "testing", "test-repo", "hello-world",
+    "Jesssullivan",  # profile repo itself
+    "jesssullivan.github.io",  # blog repo (shown separately)
+    "misc", "sk-blog-1", "cal-com-testing",
+    "TarrytownNY-Notes", "MembershipWorks-Migration",
+    "DLADocs", "dla-hugo", "pages_columbari",
+    "stub_mo_image_classify", "tmpUI",
 }
+
+# Limits for table sizes
+MAX_ORIGINAL_REPOS = 20
+MAX_FORKS = 15
 
 QUERY = """
 {
@@ -35,6 +41,7 @@ QUERY = """
         primaryLanguage { name }
         stargazerCount
         isFork
+        pushedAt
         parent { nameWithOwner }
       }
     }
@@ -72,40 +79,106 @@ def should_include(repo):
     return True
 
 
+def build_activity_section(repos):
+    """Build the 'Currently working on' section from the most recently pushed repo."""
+    if not repos:
+        return ""
+    top = repos[0]
+    name = top["name"]
+    url = top["url"]
+    desc = top.get("description") or ""
+    lang = top.get("primaryLanguage")
+    lang_name = lang["name"] if lang else ""
+    pushed = top.get("pushedAt", "")
+    pushed_nice = _format_iso_date(pushed) if pushed else ""
+
+    lines = [
+        f"**Currently working on:** [{name}]({url})",
+    ]
+    if desc:
+        lines.append(f"  {desc}")
+    parts = []
+    if lang_name:
+        parts.append(lang_name)
+    if pushed_nice:
+        parts.append(f"last push {pushed_nice}")
+    if parts:
+        lines.append(f"  *{' · '.join(parts)}*")
+    return "\n".join(lines)
+
+
 def build_original_table(repos):
-    """Build markdown table for non-fork (original) repos."""
+    """Build markdown table for non-fork (original) repos, limited to MAX_ORIGINAL_REPOS."""
+    shown = repos[:MAX_ORIGINAL_REPOS]
     lines = ["| Repo | Description | Lang |", "|------|-------------|------|"]
-    for repo in repos:
+    for repo in shown:
         name = repo["name"]
         desc = (repo["description"] or "").replace("|", "\\|")
+        # Truncate long descriptions
+        if len(desc) > 100:
+            desc = desc[:97] + "..."
         lang = repo.get("primaryLanguage")
         lang_name = lang["name"] if lang else ""
         url = repo["url"]
         lines.append(f"| [{name}]({url}) | {desc} | {lang_name} |")
+    remaining = len(repos) - len(shown)
+    if remaining > 0:
+        lines.append("")
+        lines.append(f"*...and [{remaining} more](https://github.com/Jesssullivan?tab=repositories&type=source)*")
     return "\n".join(lines)
 
 
 def build_forks_table(repos):
-    """Build markdown table for forked repos with star badges."""
-    lines = ["| Fork | What |", "|------|------|"]
-    for repo in repos:
+    """Build compact list for forked repos, limited to MAX_FORKS."""
+    # Prioritize forks with descriptions and stars
+    scored = sorted(repos, key=lambda r: (r.get("stargazerCount", 0), bool(r.get("description"))), reverse=True)
+    shown = scored[:MAX_FORKS]
+    lines = ["| Fork | Upstream |", "|------|----------|"]
+    for repo in shown:
         name = repo["name"]
-        desc = (repo["description"] or "").replace("|", "\\|")
+        parent = repo.get("parent", {})
+        upstream = parent.get("nameWithOwner", "") if parent else ""
         badge = f"![](https://img.shields.io/github/stars/Jesssullivan/{name}?style=social&label={name})"
-        lines.append(f"| {badge} | {desc} |")
+        upstream_link = f"[{upstream}](https://github.com/{upstream})" if upstream else ""
+        lines.append(f"| {badge} | {upstream_link} |")
+    remaining = len(repos) - len(shown)
+    if remaining > 0:
+        lines.append("")
+        lines.append(f"*...and [{remaining} more forks](https://github.com/Jesssullivan?tab=repositories&type=fork)*")
     return "\n".join(lines)
 
+
+def _format_iso_date(date_str):
+    """Format an ISO 8601 date string into a relative or readable date."""
+    if not date_str:
+        return ""
+    try:
+        dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        delta = now - dt
+        if delta.days == 0:
+            return "today"
+        elif delta.days == 1:
+            return "yesterday"
+        elif delta.days < 7:
+            return f"{delta.days} days ago"
+        elif delta.days < 30:
+            weeks = delta.days // 7
+            return f"{weeks} week{'s' if weeks > 1 else ''} ago"
+        else:
+            return dt.strftime("%b %d, %Y")
+    except (ValueError, TypeError):
+        return date_str[:10]
+
+
+# --- Blog feed ---
 
 BLOG_FEED_URL = "https://jesssullivan.github.io/feed.xml"
 BLOG_POST_COUNT = 3
 
 
 def fetch_blog_posts():
-    """Fetch the latest blog posts from the RSS feed.
-
-    Returns a list of dicts with 'title', 'link', and 'date' keys,
-    or an empty list if the feed is unreachable or unparseable.
-    """
+    """Fetch the latest blog posts from the RSS feed."""
     try:
         req = urllib.request.Request(
             BLOG_FEED_URL,
@@ -138,10 +211,10 @@ def fetch_blog_posts():
 
     # Try Atom format
     ns = {"atom": "http://www.w3.org/2005/Atom"}
-    entries = root.findall("atom:entry", ns)
-    if not entries:
-        entries = root.findall("entry")
-    for entry in entries[:BLOG_POST_COUNT]:
+    atom_entries = root.findall("atom:entry", ns)
+    if not atom_entries:
+        atom_entries = root.findall("entry")
+    for entry in atom_entries[:BLOG_POST_COUNT]:
         title = entry.findtext("atom:title", None, ns)
         if title is None:
             title = entry.findtext("title", "Untitled")
@@ -203,6 +276,8 @@ def build_blog_section(posts):
     return "\n".join(lines)
 
 
+# --- Section updater ---
+
 def update_section(content, section_name, new_content):
     """Replace content between START_SECTION:<name> and END_SECTION:<name> markers."""
     pattern = rf"(<!--START_SECTION:{section_name}-->).*?(<!--END_SECTION:{section_name}-->)"
@@ -220,33 +295,31 @@ def main():
     originals = [r for r in included if not r["isFork"]]
     forks = [r for r in included if r["isFork"]]
 
-    print(f"Found {len(originals)} original repos, {len(forks)} forks")
-
-    # Build the combined section content
-    section_parts = []
-
-    # Original Projects table
-    section_parts.append("")
-    section_parts.append(build_original_table(originals))
-    section_parts.append("")
-
-    # FOSS Contributions heading + table
-    section_parts.append("### FOSS Contributions")
-    section_parts.append("")
-    section_parts.append(build_forks_table(forks))
-
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    section_parts.append("")
-    section_parts.append(f"*Last updated: {now}*")
-
-    section_content = "\n".join(section_parts)
+    print(f"Found {len(originals)} original repos, {len(forks)} forks (from {len(repos)} total)")
 
     with open(README_PATH, "r") as f:
         content = f.read()
 
-    content = update_section(content, "repos", section_content)
+    # Update activity section
+    activity = build_activity_section(originals)
+    content = update_section(content, "activity", activity)
+    print(f"Updated activity: {originals[0]['name'] if originals else 'none'}")
 
-    # Update blog section (gracefully skipped if feed is unavailable)
+    # Update repos section
+    section_parts = []
+    section_parts.append("")
+    section_parts.append(build_original_table(originals))
+    section_parts.append("")
+    section_parts.append("### FOSS Contributions")
+    section_parts.append("")
+    section_parts.append(build_forks_table(forks))
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    section_parts.append("")
+    section_parts.append(f"*Last updated: {now}*")
+    content = update_section(content, "repos", "\n".join(section_parts))
+    print(f"Updated repos: {min(len(originals), MAX_ORIGINAL_REPOS)} shown, {min(len(forks), MAX_FORKS)} forks")
+
+    # Update blog section
     blog_posts = fetch_blog_posts()
     if blog_posts:
         blog_content = build_blog_section(blog_posts)
@@ -258,7 +331,7 @@ def main():
     with open(README_PATH, "w") as f:
         f.write(content)
 
-    print(f"Updated README with {len(originals)} original repos and {len(forks)} forks")
+    print("Done.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add dynamic "Currently working on" section showing most recently pushed repo with relative timestamps
- Expand blocklist (test repos, blog repo, trivial notebooks)
- Limit tables: 20 original repos, 15 forks (sorted by stars) with "see more" links
- Truncate long descriptions, show upstream repo links for forks
- Add pushedAt to GraphQL query for activity tracking

## Test plan
- [x] Script runs locally, generates clean README
- [ ] Action workflow updates README on push