### PR TITLE
Enrich README: expanded FOSS, sponsorships, client badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=36BCF7&center=true&vCenter=true&width=500&lines=Systems+Analyst+%7C+FOSS+Contributor;Chapel+%7C+Futhark+%7C+Haskell+%7C+Nix;Hardware+Hacker+%7C+Birder+%7C+Maker)](https://git.io/typing-svg)
+[![Typing SVG](https://readme-typing-svg.demolab.com?font=Fira+Code&pause=1000&color=36BCF7&center=true&vCenter=true&width=600&lines=Systems+Analyst+%7C+FOSS+Contributor+%7C+Hardware+Hacker;Chapel+%7C+Futhark+%7C+Haskell+%7C+Nix+%7C+Go;Merlin+Sound+ID+%7C+Birder+%7C+Maker+%7C+Musician)](https://git.io/typing-svg)
 
 ![Profile Views](https://komarev.com/ghpvc/?username=Jesssullivan&color=blueviolet&style=flat-square&label=PROFILE+VIEWS)
 
@@ -11,10 +11,15 @@
 
 ### Jess Sullivan
 
+Full stack engineer, musician, and birdwatcher based in Lewiston, ME.
+
 I spent about a year completely offline — no LinkedIn, no blog, no social media.
 Late 2023 through the end of 2024. An intentional disconnect.
 
-I'm back now, rebuilding and picking up where I left off.
+I'm back now, rebuilding in the open. I build infrastructure tooling, contribute to compilers
+and languages, hack on hardware, and maintain a lot of FOSS. Previously at Cornell's
+Macaulay Library, where I helped develop and launch
+[Merlin Sound ID](https://merlin.allaboutbirds.org/) — used by millions of birders worldwide.
 
 **Lewiston, ME** · [transscendsurvival.org](https://transscendsurvival.org) · Pro
 
@@ -46,16 +51,33 @@ mindmap
 
 ---
 
-### Affiliations & Memberships
+### FOSS Contributions & Memberships
 
 ![Rocky Linux](https://img.shields.io/badge/RESF-10B981?style=for-the-badge&logo=rockylinux&logoColor=white)
-![Apache](https://img.shields.io/badge/Apache%20Solr-D22128?style=for-the-badge&logo=apache&logoColor=white)
+![Apache Solr](https://img.shields.io/badge/Apache%20Solr-D22128?style=for-the-badge&logo=apache&logoColor=white)
 ![Chapel](https://img.shields.io/badge/Chapel-141C25?style=for-the-badge&logoColor=white)
 ![Liqo / CERN](https://img.shields.io/badge/Liqo%20%2F%20CERN-0053A1?style=for-the-badge&logo=cern&logoColor=white)
 ![Skeleton UI](https://img.shields.io/badge/Skeleton%20UI-EC4899?style=for-the-badge&logo=svelte&logoColor=white)
 ![SearXNG](https://img.shields.io/badge/SearXNG-2E8B57?style=for-the-badge&logo=searxng&logoColor=white)
 ![KeePassXC](https://img.shields.io/badge/KeePassXC-6CAC4D?style=for-the-badge&logo=keepassxc&logoColor=white)
 ![Futhark](https://img.shields.io/badge/Futhark-5e5086?style=for-the-badge&logoColor=white)
+![Klipper](https://img.shields.io/badge/Klipper-B71C1C?style=for-the-badge&logo=klipper&logoColor=white)
+![Caddy](https://img.shields.io/badge/Caddy-1F88E5?style=for-the-badge&logo=caddy&logoColor=white)
+![BrainFlow](https://img.shields.io/badge/BrainFlow-7B1FA2?style=for-the-badge&logoColor=white)
+![EyeTrackVR](https://img.shields.io/badge/EyeTrackVR-FF6F00?style=for-the-badge&logoColor=white)
+![fft.js](https://img.shields.io/badge/fft.js-333333?style=for-the-badge&logo=javascript&logoColor=F7DF1E)
+![Freenet](https://img.shields.io/badge/Freenet-1565C0?style=for-the-badge&logoColor=white)
+![MeshCore](https://img.shields.io/badge/MeshCore-00897B?style=for-the-badge&logoColor=white)
+![libdns](https://img.shields.io/badge/libdns-00695C?style=for-the-badge&logo=go&logoColor=white)
+
+### Sponsoring
+
+![The-Compiler](https://img.shields.io/badge/The--Compiler-Florian%20Bruhin-blueviolet?style=for-the-badge&logo=githubsponsors&logoColor=white)
+![qutebrowser](https://img.shields.io/badge/qutebrowser-0D47A1?style=for-the-badge&logoColor=white)
+![pytest](https://img.shields.io/badge/pytest-0A9EDC?style=for-the-badge&logo=pytest&logoColor=white)
+![Xe Iaso](https://img.shields.io/badge/Xe%20Iaso%20%2F%20TequaroHQ-E91E63?style=for-the-badge&logo=githubsponsors&logoColor=white)
+![Skeleton](https://img.shields.io/badge/Skeleton-EC4899?style=for-the-badge&logo=githubsponsors&logoColor=white)
+![purpl3F0x](https://img.shields.io/badge/purpl3F0x-9C27B0?style=for-the-badge&logo=githubsponsors&logoColor=white)
 
 ---
 
@@ -66,14 +88,21 @@ mindmap
 <td width="50%" valign="top">
 
 **Systems Analyst (DevSecOps)** — Bates College *(2024–Present)*
-- Legacy modernization, Ansible, degree audit orchestration (Haskell + Python)
+- Legacy modernization, bespoke Ansible extensions, roles & plugins
+- Degree audit orchestration tooling (Haskell + Python, QuickCheck, Cabal, FPM)
+- Event management system overhaul (C#, Go, Ansible)
 - Apache Solr adoption, ACME cert management, SAML integrations
 - GitLab AutoDevOps, OpenTofu, RKE2 + Rancher
 
 **CV/ML Software Engineer** — Macaulay Library *(2018–2022)*
-- Developed & launched Merlin Sound ID
-- ML annotation tools, model evaluation APIs
-- Python, TensorFlow, Flask, TypeScript, Docker, WASM
+- Developed & launched [Merlin Sound ID](https://merlin.allaboutbirds.org/) & The Machine Learning Blog
+- Fine-grained ML annotation tools for audio classification
+- Internal classification & model evaluation web APIs
+- Python (TensorFlow, NumPy, Pandas), Flask, TypeScript, Docker, WASM
+
+**Fabrication Lab Manager** — Cornell CALS *(2021–2022)*
+- Rapid fabrication curricula for Landscape Architecture students & faculty
+- OpenSCAD, Fusion 360, C++ tiler development
 
 </td>
 <td width="50%" valign="top">
@@ -84,8 +113,14 @@ mindmap
 - Chapel, Python, Go, K8s (Liqo), Apache Solr
 
 **Columbari.us LLC** *(2017–2021)*
-- GIS & ML contractor
-- NPS, Foundation for Healthy Communities, GPRED, NBRC
+- Independent contractor in GIS & ML
+
+Clients:
+
+![NPS](https://img.shields.io/badge/National%20Park%20Service-006B3F?style=flat-square&logo=nps&logoColor=white)
+![FHC](https://img.shields.io/badge/Foundation%20for%20Healthy%20Communities-1976D2?style=flat-square)
+![GPRED](https://img.shields.io/badge/GPRED-5D4037?style=flat-square)
+![NBRC](https://img.shields.io/badge/Northern%20Border%20Regional%20Commission-37474F?style=flat-square)
 
 </td>
 </tr>
@@ -95,9 +130,9 @@ mindmap
 
 - **RESF Community Member** — Rocky Enterprise Linux Foundation
 - **First Fellow** — D&M Makerspace, Plymouth State University *(2017–2020)*
-- **Membership Chair & 3D Printing Captain** — Ithaca Generator *(2020–2022)*
-- **COVID-19 PPE coordination** across New England makerspaces
 - Taught Advanced GIS Programming & Intro to Electromechanics at PSU
+- **Membership Chair & 3D Printing Captain** — Ithaca Generator *(2020–2022)*
+- **COVID-19 PPE manufacturing coordination** across New England makerspaces
 
 ---
 
@@ -308,6 +343,7 @@ timeline
 [![Blog](https://img.shields.io/badge/Blog-transscendsurvival.org-36BCF7?style=flat-square)](https://transscendsurvival.org)
 [![GitHub](https://img.shields.io/badge/GitHub-Jesssullivan-181717?style=flat-square&logo=github)](https://github.com/Jesssullivan)
 [![CV](https://img.shields.io/badge/CV-Download%20PDF-green?style=flat-square)](https://transscendsurvival.org/cv)
+[![Sponsor](https://img.shields.io/badge/Sponsor-Jesssullivan-ea4aaa?style=flat-square&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/Jesssullivan)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Added 8 new FOSS contribution badges: Klipper, Caddy, BrainFlow, EyeTrackVR, fft.js, Freenet, MeshCore, libdns
- Added Sponsoring section with badges: The-Compiler (qutebrowser/pytest), Xe Iaso/TequaroHQ, Skeleton, purpl3F0x
- Added client work badges under Columbari.us: NPS, Foundation for Healthy Communities, GPRED, NBRC
- Enriched bio prose with Merlin Sound ID callout and fuller narrative
- Added Cornell CALS Fab Lab Manager role to Experience
- Added Sponsor badge to footer links
- Expanded typing SVG with additional descriptors

## Test plan
- [ ] Verify all shields.io badges render on GitHub
- [ ] Confirm dynamic sections still intact (activity, blog, repos markers)
- [ ] Check two-column layout renders correctly
- [ ] Verify Mermaid diagrams still render

Generated with [Claude Code](https://claude.com/claude-code)